### PR TITLE
Get unique product ids at specific prices

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3276,11 +3276,16 @@ class ProductCore extends ObjectModel
         $ids_product = Product::_getProductIdByDate((!$beginning ? $current_date : $beginning), (!$ending ? $current_date : $ending), $context);
 
         $tab_id_product = [];
+        
         foreach ($ids_product as $product) {
             if (is_array($product)) {
-                $tab_id_product[] = (int) $product['id_product'];
+                if(!in_array($product['id_product'], $tab_id_product)){
+                    $tab_id_product[] = (int) $product['id_product'];
+                }
             } else {
-                $tab_id_product[] = (int) $product;
+                if(!in_array((int) $product, $tab_id_product)){
+                    $tab_id_product[] = (int) $product;
+                }
             }
         }
 


### PR DESCRIPTION
We filter the repeated ids in the specific price table so that they do not pass to the query since they generate slow querys when the query has thousands of identifiers.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | thousands of repeating identifiers generate a slow query in method getPricesDrop
| Type?             | improvement
| Category?         | 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | 
| How to test?      | From 70000 identifiers it was changed to only 3000 and the slow query disappeared from our logs.
| Possible impacts? | Product class


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
